### PR TITLE
feat: Add mobile-optimized styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,3 +171,56 @@
             body { padding-top: 60px; }
             .search-box { top: 5px; }
         }
+
+        /* 추가된 모바일 최적화 스타일 */
+        @media (max-width: 480px) {
+            body {
+                padding-top: 55px; /* 상단 패딩 축소 */
+            }
+            .container {
+                padding: 15px; /* 컨테이너 패딩 축소 */
+                border-radius: 16px; /* 컨테이너 모서리 둥글기 조정 */
+            }
+            .menu-toggle-button {
+                top: 12px; left: 12px;
+                padding: 5px 9px;
+                font-size: 1.1em;
+            }
+            .sidebar-menu {
+                width: 230px; /* 사이드바 너비 축소 */
+                padding-top: 55px;
+            }
+            .search-input {
+                padding: 14px 20px;
+                font-size: 0.95em;
+            }
+            .page-specific-content .header {
+                padding: 25px; /* 헤더 패딩 축소 */
+                border-radius: 16px;
+            }
+            .page-specific-content .course-title {
+                font-size: 1.4em; /* 제목 폰트 크기 조정 */
+            }
+            .page-specific-content .course-date {
+                font-size: 1em;
+            }
+            .question-group {
+                padding: 20px; /* 질문 그룹 패딩 조정 */
+                border-radius: 12px;
+            }
+            .verse {
+                padding: 16px; /* 구절 패딩 조정 */
+                border-radius: 10px;
+            }
+            .verse-text {
+                font-size: 1em; /* 구절 텍스트 폰트 크기를 키워 가독성 확보 */
+                line-height: 1.65;
+            }
+            .verse-reference {
+                font-size: 0.95em;
+            }
+            .footer {
+                padding: 25px;
+                border-radius: 16px;
+            }
+        }


### PR DESCRIPTION
This commit introduces a new media query for screens with a max-width of 480px to provide a better user experience on smaller mobile devices.

The changes include:
- Adjusting font sizes for improved readability, especially for the verse text.
- Reducing padding and margins on various elements to make better use of screen real estate.
- Fine-tuning the layout of the header, container, and other components for a more compact and mobile-friendly design.